### PR TITLE
Fix rails 7.1 error

### DIFF
--- a/lib/temping/model_factory.rb
+++ b/lib/temping/model_factory.rb
@@ -21,7 +21,7 @@ class Temping::ModelFactory
     Class.new(parent_class_name).tap do |klass|
       @namespace.const_set(@name, klass)
       klass.primary_key = @options[:primary_key] || :id
-      create_table(@options)
+      create_table(@options.except(:parent_class))
       add_methods
       klass.namespace = @namespace
     end


### PR DESCRIPTION
Fix rails 7.1 error:
```
Failures:

  1) Temping.create with a custom parent class uses the provided parent class option
     Failure/Error: connection.create_table(table_name, **DEFAULT_OPTIONS.merge(options))

     ArgumentError:
       Unknown key: :parent_class. Valid keys are: :temporary, :if_not_exists, :options, :as, :comment, :charset, :collation, :rename, :limit, :default, :precision
```

Basically we just need to skip this key when passing options to `create_table`.